### PR TITLE
Add jump-to filter for Scott numbers with enhanced UX

### DIFF
--- a/internal/database/querybuilder.go
+++ b/internal/database/querybuilder.go
@@ -109,3 +109,18 @@ func (qb *QueryBuilder) AddWhereCondition(column string, operator string, value 
 func (qb *QueryBuilder) AddDeletedFilter(tableAlias string) {
 	qb.AddCondition(fmt.Sprintf(` AND %s.date_deleted IS NULL`, tableAlias))
 }
+
+// AddJumpToFilter adds a condition to filter stamps with Scott numbers >= specified value
+func (qb *QueryBuilder) AddJumpToFilter(jumpToScottNumber string, tableAlias string) {
+	if jumpToScottNumber != "" {
+		// For numeric Scott numbers, compare numerically
+		// For non-numeric Scott numbers, compare alphabetically
+		qb.AddCondition(fmt.Sprintf(`
+			AND (
+				(%s.scott_number ~ '^\d+' AND CAST(SUBSTRING(%s.scott_number FROM '\d+') AS INTEGER) >= ?)
+				OR
+				(%s.scott_number !~ '^\d+' AND %s.scott_number >= ?)
+			)`, tableAlias, tableAlias, tableAlias, tableAlias),
+			jumpToScottNumber, jumpToScottNumber)
+	}
+}

--- a/internal/handlers/views.go
+++ b/internal/handlers/views.go
@@ -207,13 +207,18 @@ func (h *ViewHandler) GetBoxesView(w http.ResponseWriter, r *http.Request) {
 	// Get user preferences to pass to template
 	prefs := h.sessionMiddleware.GetPreferences(r)
 
+	// Get the currently active box ID from query parameters
+	activeBoxID := r.URL.Query().Get("box_id")
+
 	// Create data structure that includes both boxes and preferences
 	data := struct {
 		Boxes       interface{}
 		Preferences middleware.UserPreferences
+		ActiveBoxID string
 	}{
 		Boxes:       boxes,
 		Preferences: prefs,
+		ActiveBoxID: activeBoxID,
 	}
 
 	err = h.templates.ExecuteTemplate(w, "box-list.html", data)

--- a/internal/services/stamps.go
+++ b/internal/services/stamps.go
@@ -19,13 +19,14 @@ type StampService struct {
 
 // StampFilters holds all filter parameters for stamp queries
 type StampFilters struct {
-	Search string
-	Owned  string
-	BoxID  string
-	Sort   string
-	Order  string
-	Limit  int
-	Offset int
+	Search     string
+	Owned      string
+	BoxID      string
+	JumpTo     string
+	Sort       string
+	Order      string
+	Limit      int
+	Offset     int
 }
 
 // NewStampFiltersFromRequest creates StampFilters from HTTP request parameters
@@ -59,6 +60,7 @@ func NewStampFiltersFromRequest(r *http.Request, page, limit int) StampFilters {
 		Search: r.URL.Query().Get("search"),
 		Owned:  owned,
 		BoxID:  r.URL.Query().Get("box_id"),
+		JumpTo: r.URL.Query().Get("jump_to"),
 		Sort:   r.URL.Query().Get("sort"),
 		Order:  order,
 		Limit:  limit,
@@ -103,6 +105,7 @@ func (s *StampService) GetStamps(r *http.Request, page, limit int) ([]models.Sta
 // Helper method to build query with filters
 func (s *StampService) addStampFilters(qb *database.QueryBuilder, filters StampFilters) {
 	qb.AddSearchFilter(filters.Search, "s")
+	qb.AddJumpToFilter(filters.JumpTo, "s")
 	
 	if filters.Owned == "true" {
 		qb.AddCondition(` AND EXISTS (SELECT 1 FROM stamp_instances si WHERE si.stamp_id = s.id AND si.date_deleted IS NULL)`)

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -68,6 +68,57 @@ main {
     margin-bottom: 2rem;
 }
 
+.jump-to-container {
+    margin-top: 0.5rem;
+}
+
+.jump-to-input-wrapper {
+    position: relative;
+}
+
+.jump-to-container .form-control-sm {
+    font-size: 0.875rem;
+    padding-right: 2rem;
+}
+
+/* Hide number input spinner arrows */
+.jump-to-container input[type="number"]::-webkit-outer-spin-button,
+.jump-to-container input[type="number"]::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+}
+
+/* .jump-to-container input[type="number"] {
+    -moz-appearance: textfield;
+} */
+
+.jump-to-clear-btn {
+    position: absolute;
+    right: 0.5rem;
+    top: 50%;
+    transform: translateY(-50%);
+    background: none;
+    border: none;
+    color: var(--sk-subtle-text);
+    cursor: pointer;
+    padding: 0;
+    width: 1rem;
+    height: 1rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.875rem;
+}
+
+.jump-to-clear-btn:hover {
+    color: var(--sk-text-color);
+}
+
+.jump-to-container .form-text {
+    font-size: 0.75rem;
+    margin-top: 0.25rem;
+}
+
 #box-list .list-group-item {
     background: none;
     border: none;

--- a/templates/box-list.html
+++ b/templates/box-list.html
@@ -3,18 +3,20 @@
      hx-swap="innerHTML" 
      hx-indicator="#loading-spinner">
 
-    <a href="#" class="list-group-item list-group-item-action active"
+    <a href="#" class="list-group-item list-group-item-action{{if eq .ActiveBoxID ""}} active{{end}}"
         hx-get="/views/stamps/{{.Preferences.DefaultView}}" 
         hx-trigger="click"
-        hx-include="[name='search'], [name='owned_filter']:checked">
+        hx-include="[name='search'], [name='jump_to'], [name='owned_filter']:checked"
+        hx-on::after-request="htmx.ajax('GET', '/views/boxes-list', '#box-list')">
         All Boxes
     </a>
 
     {{range .Boxes}}
-    <a href="#" class="list-group-item list-group-item-action"
+    <a href="#" class="list-group-item list-group-item-action{{if eq $.ActiveBoxID .ID}} active{{end}}"
         hx-get="/views/stamps/{{$.Preferences.DefaultView}}?box_id={{.ID}}"
         hx-trigger="click"
-        hx-include="[name='search'], [name='owned_filter']:checked">
+        hx-include="[name='search'], [name='jump_to'], [name='owned_filter']:checked"
+        hx-on::after-request="htmx.ajax('GET', '/views/boxes-list?box_id={{.ID}}', '#box-list')">
         <span>{{.Name}}</span>
         <span class="badge rounded-pill">{{.StampCount}}</span>
     </a>

--- a/templates/index.html
+++ b/templates/index.html
@@ -41,20 +41,44 @@
                             <input type="radio" class="btn-check" name="owned_filter" id="filter_all" autocomplete="off" checked value="all"
                                 hx-get="/views/stamps/{{.Preferences.DefaultView}}" 
                                 hx-trigger="change"
-                                hx-include="[name='search'], #box-list .list-group-item.active">
+                                hx-include="[name='search'], [name='jump_to'], #box-list .list-group-item.active">
                             <label class="btn btn-outline-secondary text-start" for="filter_all">All Stamps</label>
 
                             <input type="radio" class="btn-check" name="owned_filter" id="filter_owned" autocomplete="off" value="true"
                                 hx-get="/views/stamps/{{.Preferences.DefaultView}}" 
                                 hx-trigger="change"
-                                hx-include="[name='search'], #box-list .list-group-item.active">
+                                hx-include="[name='search'], [name='jump_to'], #box-list .list-group-item.active">
                             <label class="btn btn-outline-secondary text-start" for="filter_owned">Owned</label>
                             
                             <input type="radio" class="btn-check" name="owned_filter" id="filter_needed" autocomplete="off" value="false"
                                 hx-get="/views/stamps/{{.Preferences.DefaultView}}" 
                                 hx-trigger="change"
-                                hx-include="[name='search'], #box-list .list-group-item.active">
+                                hx-include="[name='search'], [name='jump_to'], #box-list .list-group-item.active">
                             <label class="btn btn-outline-secondary text-start" for="filter_needed">Needed</label>
+                        </div>
+                    </div>
+
+                    <div class="sidebar-section">
+                        <h6 class="sidebar-heading">Jump To Scott #</h6>
+                        <div class="jump-to-container">
+                            <div class="jump-to-input-wrapper">
+                                <input type="number" 
+                                       class="form-control form-control-sm" 
+                                       name="jump_to" 
+                                       placeholder="e.g. 4000"
+                                       min="1"
+                                       hx-get="/views/stamps/{{.Preferences.DefaultView}}"
+                                       hx-trigger="keyup changed delay:500ms"
+                                       hx-target="#stamp-view-content"
+                                       hx-indicator="#loading-spinner"
+                                       hx-include="[name='search'], [name='owned_filter']:checked, #box-list .list-group-item.active">
+                                <button type="button" class="jump-to-clear-btn" title="Clear jump to filter"
+                                        onclick="clearJumpTo()"
+                                        style="display: none;">
+                                    <i class="bi bi-x"></i>
+                                </button>
+                            </div>
+                            <small class="form-text text-muted">Shows stamps with Scott # ≥ this value</small>
                         </div>
                     </div>
 
@@ -91,7 +115,7 @@
                                hx-trigger="keyup changed delay:500ms, search"
                                hx-target="#stamp-view-content"
                                hx-indicator="#loading-spinner"
-                               hx-include="[name='owned_filter']:checked, #box-list .list-group-item.active">
+                               hx-include="[name='jump_to'], [name='owned_filter']:checked, #box-list .list-group-item.active">
                     </div>
                     <div class="settings-container d-flex gap-3 align-items-center">
                         <!-- View Toggle Buttons -->
@@ -103,7 +127,7 @@
                                        hx-target="#stamp-view-content"
                                        hx-trigger="click"
                                        hx-indicator="#loading-spinner"
-                                       hx-include="[name='search'], [name='owned_filter']:checked, #box-list .list-group-item.active">
+                                       hx-include="[name='search'], [name='jump_to'], [name='owned_filter']:checked, #box-list .list-group-item.active">
                                     <i class="bi bi-grid-3x3-gap"></i> Gallery
                                 </label>
 
@@ -113,7 +137,7 @@
                                        hx-target="#stamp-view-content"
                                        hx-trigger="click"
                                        hx-indicator="#loading-spinner"
-                                       hx-include="[name='search'], [name='owned_filter']:checked, #box-list .list-group-item.active">
+                                       hx-include="[name='search'], [name='jump_to'], [name='owned_filter']:checked, #box-list .list-group-item.active">
                                     <i class="bi bi-list-ul"></i> List
                                 </label>
                             </div>
@@ -176,6 +200,30 @@
             // Use server-side preferences to determine default view
             htmx.ajax('GET', '/views/default', '#stamp-view-content');
         };
+
+        // Jump-to clear functionality
+        window.clearJumpTo = function() {
+            const jumpToInput = document.querySelector('[name="jump_to"]');
+            const clearBtn = document.querySelector('.jump-to-clear-btn');
+            
+            if (jumpToInput) {
+                jumpToInput.value = '';
+                jumpToInput.dispatchEvent(new Event('keyup')); // Trigger HTMX request
+                if (clearBtn) {
+                    clearBtn.style.display = 'none';
+                }
+            }
+        };
+
+        // Show/hide clear button based on input value
+        document.addEventListener('input', function(evt) {
+            if (evt.target.name === 'jump_to') {
+                const clearBtn = document.querySelector('.jump-to-clear-btn');
+                if (clearBtn) {
+                    clearBtn.style.display = evt.target.value ? 'flex' : 'none';
+                }
+            }
+        });
     </script>
     
     <script src="/static/js/alpine-components.js"></script>


### PR DESCRIPTION
This feature allows users to quickly navigate to stamps with specific Scott numbers without scrolling through large collections.

## Features Added:
- Jump-to input field in sidebar for Scott number filtering
- Smart filtering that handles both numeric and non-numeric Scott numbers
- Clear button (X) for quick field reset
- Integration with all existing filters (owned/needed, storage boxes, search)
- Persistent box selection with correct active state visualization
- Real-time filtering with 500ms delay using HTMX

## Backend Changes:
- Added AddJumpToFilter() method to QueryBuilder for numeric/text comparison
- Extended StampFilters struct with JumpTo field
- Updated GetBoxesView handler to track active box selection
- Integrated jump_to parameter throughout filter chain

## Frontend Changes:
- New sidebar section with number input and clear functionality
- Updated all HTMX interactions to preserve jump_to parameter
- CSS styling for clean input appearance (no spinner arrows)
- JavaScript for clear button show/hide and field reset
- Fixed box selection active state persistence

## Usage:
Enter a Scott number (e.g., 4000) to show stamps with Scott # ≥ that value. Works seamlessly with other filters for precise collection navigation.

🤖 Generated with [Claude Code](https://claude.ai/code)